### PR TITLE
Create cache.yml

### DIFF
--- a/.github/workflows/cache.yml
+++ b/.github/workflows/cache.yml
@@ -1,0 +1,51 @@
+permissions:
+  contents: read
+name: Cache
+
+on:
+  push:
+    branches:
+      - 0xSequencemaster
+      - master
+      - pre-release-testing-branch
+      - changeset-release/main
+      - v-next
+    paths:
+      - ".github/workflows/cache.yml"
+      - "**/pnpm-lock.yaml"
+  pull_request:
+    paths:
+      - ".github/workflows/cache.yml"
+      - "**/pnpm-lock.yaml"
+  workflow_dispatch:
+
+concurrency:
+  group: ${{github.workflow}}-${{github.ref}}
+  cancel-in-progress: true
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  cache:
+    name: Cache
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        runner: ["ubuntu-latest", "macos-latest", "windows-latest"]
+    steps:
+      - uses: actions/checkout@v4
+      - id: env
+        uses: ./.github/actions/setup-env
+        with:
+          cache-save: true
+      - name: Install
+        if: steps.env.outputs.cache-hit != 'true'
+        run: |
+          for lockfile in $(find "$(pwd)" -name pnpm-lock.yaml); do
+            pushd "$(dirname "$lockfile")"
+              pnpm install --frozen-lockfile --prefer-offline
+            popd
+          done


### PR DESCRIPTION
## Summary by Sourcery

Introduce a dedicated GitHub Actions workflow to cache pnpm dependencies across multiple operating systems, speed up installs by skipping them on cache hits, and prevent redundant runs using concurrency controls

CI:
- Add a new 'Cache' GitHub Actions workflow to save and restore pnpm dependency caches
- Configure the workflow to run on pushes to key branches, pull requests involving lockfile changes, and manual dispatch
- Use a concurrency group to cancel in-progress cache jobs for the same workflow and ref
- Define a matrix across Ubuntu, macOS, and Windows for consistent caching behavior
- Conditionally install pnpm dependencies with frozen lockfile only on cache misses across all projects